### PR TITLE
Updated plugin enabling functions to be properly underscored

### DIFF
--- a/addons/escoria-core/plugin.gd
+++ b/addons/escoria-core/plugin.gd
@@ -7,7 +7,7 @@ var popup_info: AcceptDialog
 
 
 # Virtual function called when plugin is enabled.
-func enable_plugin():
+func _enable_plugin():
 	add_autoload_singleton(
 		"escoria",
 		"res://addons/escoria-core/game/esc_autoload.gd"

--- a/addons/escoria-dialog-simple/plugin.gd
+++ b/addons/escoria-dialog-simple/plugin.gd
@@ -65,7 +65,7 @@ func _disable_plugin():
 
 
 # Add ourselves to the list of dialog managers
-func enable_plugin():
+func _enable_plugin():
 	print("Enabling plugin Escoria Dialog Simple")
 
 	if EscoriaPlugin.register_dialog_manager(self, MANAGER_CLASS):

--- a/addons/escoria-ui-9verbs/plugin.gd
+++ b/addons/escoria-ui-9verbs/plugin.gd
@@ -15,7 +15,7 @@ func _disable_plugin():
 
 
 # Register UI with Escoria
-func enable_plugin():
+func _enable_plugin():
 	print("Enabling plugin Escoria UI 9-verbs.")
 	if not EscoriaPlugin.register_ui(self, "res://addons/escoria-ui-9verbs/game.tscn"):
 		get_editor_interface().set_plugin_enabled(

--- a/addons/escoria-ui-keyboard-9verbs/plugin.gd
+++ b/addons/escoria-ui-keyboard-9verbs/plugin.gd
@@ -15,7 +15,7 @@ func _disable_plugin() -> void:
 
 
 # Register UI with Escoria
-func enable_plugin():
+func _enable_plugin():
 	print("Enabling plugin Escoria UI 9-verbs with keyboard.")
 	if not EscoriaPlugin.register_ui(self, "res://addons/escoria-ui-keyboard-9verbs/game.tscn"):
 		get_editor_interface().set_plugin_enabled(

--- a/addons/escoria-ui-simplemouse/plugin.gd
+++ b/addons/escoria-ui-simplemouse/plugin.gd
@@ -15,7 +15,7 @@ func _disable_plugin():
 
 
 # Register UI with Escoria
-func enable_plugin():
+func _enable_plugin():
 	print("Enabling plugin Escoria UI Simple Mouse.")
 	if not EscoriaPlugin.register_ui(self, "res://addons/escoria-ui-simplemouse/game.tscn"):
 		get_editor_interface().set_plugin_enabled(

--- a/addons/escoria-wizard/plugin.gd
+++ b/addons/escoria-wizard/plugin.gd
@@ -48,7 +48,7 @@ func _disable_plugin():
 	)
 
 # Register ourselves
-func enable_plugin():
+func _enable_plugin():
 	print("Enabling Escoria Wizard plugin")
 	ESCProjectSettingsManager.register_setting(
 		"escoria/wizard/path_to_rooms",


### PR DESCRIPTION
None of the plugin stuff was triggering on enable, causing none of the settings or tabs to show up properly when I moved the clone into a new project

https://docs.godotengine.org/en/stable/classes/class_editorplugin.html#class-editorplugin-private-method-enable-plugin